### PR TITLE
Fix AttributeError on model names

### DIFF
--- a/binoculars/utils.py
+++ b/binoculars/utils.py
@@ -7,4 +7,4 @@ def assert_tokenizer_consistency(model_id_1, model_id_2):
             == AutoTokenizer.from_pretrained(model_id_2).vocab
     )
     if not identical_tokenizers:
-        raise ValueError(f"Tokenizers are not identical for {model_id_1.name_of_path} and {model_id_2.name_of_path}.")
+        raise ValueError(f"Tokenizers are not identical for {model_id_1} and {model_id_2}.")


### PR DESCRIPTION
When the ValueError exception should be raised, it raises instead: 

`AttributeError: 'str' object has no attribute 'name_of_path'` 

Because model_id_1 and model_id_2 are strings, with no attribute 'name_of_path'.
Directly using the strings fixed the issue.