### PR TITLE
Fixed Import Error

### DIFF
--- a/binoculars/__init__.py
+++ b/binoculars/__init__.py
@@ -1,4 +1,3 @@
-from config import huggingface_config
 from .detector import Binoculars
 
 __all__ = ["Binoculars"]

--- a/binoculars/detector.py
+++ b/binoculars/detector.py
@@ -1,15 +1,20 @@
 from typing import Union
 
+import os
 import numpy as np
 import torch
 import transformers
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from config import huggingface_config
 from .utils import assert_tokenizer_consistency
 from .metrics import perplexity, entropy
 
 torch.set_grad_enabled(False)
+
+huggingface_config = {
+    # Only required for private models from Huggingface (e.g. LLaMA models)
+    "TOKEN": os.environ.get("HF_TOKEN", None)
+}
 
 # selected using Falcon-7B and Falcon-7B-Instruct at bfloat16
 BINOCULARS_ACCURACY_THRESHOLD = 0.9015310749276843  # optimized for f1-score

--- a/config.py
+++ b/config.py
@@ -1,6 +1,0 @@
-import os
-
-huggingface_config = {
-    # Only required for private models from Huggingface (e.g. LLaMA models)
-    "TOKEN": os.environ.get("HF_TOKEN", None)
-}


### PR DESCRIPTION
When installing Binoculars through `pip install`, trying to run the code results in an import error to do with `config.py`. This PR moves the contents of this config file such that there is no longer an import error.