### PR TITLE
Bump transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,31 @@ Detection of Machine-Generated Text**.
 
 ### Installation
 
-To run the implementation of Binoculars, you can clone this repository and install the package using pip. This code was
-developed and tested on Python This code was developed and tested with Python 3.9. To install the package, run the
-following commands:
+**Prerequisites:** Python 3.9 or higher
+
+**Option 1: Install from source (recommended for development)**
+
+Clone the repository and install in editable mode:
 
 ```bash
-$ git clone https://github.com/ahans30/Binoculars.git
-$ cd Binoculars
-$ pip install -e .
+git clone https://github.com/ahans30/Binoculars.git
+cd Binoculars
+pip install -e .
+```
+
+**Option 2: Install dependencies only**
+
+If you've already cloned the repository:
+
+```bash
+cd Binoculars
+pip install -r requirements.txt
+```
+
+**Verify installation:**
+
+```bash
+python -c "from binoculars import Binoculars; print('Installation successful!')"
 ```
 
 ### Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sentencepiece
-transformers[torch] @ https://github.com/huggingface/transformers/archive/refs/tags/v4.31.0.zip
+transformers[torch]>=4.40.0
 datasets
 numpy
 gradio


### PR DESCRIPTION
**Problem:** The original requirements.txt referenced an old version of transformers (v4.31.0) that couldn't build on Python 3.13 due to Rust compilation issues with the tokenizers package.
**Solution:** Updated requirements.txt to use transformers[torch]>=4.40.0, which includes prebuilt wheels compatible with Python 3.13.

- Improved README installation section with clearer structure
- Added prerequisites (Python 3.9+)
- Provided two installation options (editable install vs. requirements only)
- Added verification command
- Fixed duplicate text in installation section
- Updated requirements.txt to use transformers>=4.40.0 instead of pinned GitHub archive